### PR TITLE
Add Type Declarations to Project

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for react-pointable 1.1
+// Project: https://github.com/MilllerTime/react-pointable
+// Definitions by: Stefan Fochler <https://github.com/istefo>
+// TypeScript Version: 2.3
+import * as React from 'react';
+
+export type TouchAction = 'auto' | 'none' | 'pan-x' | 'pan-y' | 'manipulation';
+
+export interface PointableProps extends React.HTMLAttributes<HTMLElement> {
+	tagName?: keyof HTMLElementTagNameMap;
+	touchAction?: TouchAction;
+	elementRef?(el: HTMLElement): void;
+	onPointerMove?(evt: PointerEvent): void;
+	onPointerDown?(evt: PointerEvent): void;
+	onPointerUp?(evt: PointerEvent): void;
+	onPointerOver?(evt: PointerEvent): void;
+	onPointerOut?(evt: PointerEvent): void;
+	onPointerEnter?(evt: PointerEvent): void;
+	onPointerLeave?(evt: PointerEvent): void;
+	onPointerCancel?(evt: PointerEvent): void;
+}
+
+export default class Pointable extends React.Component<PointableProps, {}> {
+	static defaultProps: {
+		tagName: 'div',
+		touchAction: 'auto'
+	};
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "Declarative pointer event binding. Works well alongside PEP.",
   "main": "lib/index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "build": "babel src -d lib",
     "test": "jest",


### PR DESCRIPTION
Following up on #3, this is how it would look like to include typings in the package itself.

I chose to have the index.d.ts file in the projects root because the `/src` directory is not available in the NPM package and I didn't want to introduce a copy phase that copies certain files from `/src` to `/lib` during build.

What do you think, @MilllerTime?