### PR TITLE
Update README to direct users to specific version of typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ All pointer events are supported:
 Typings for projects written in TypeScript are available on NPM:
 
 ```
-npm install --save-dev @types/react-pointable
+npm install --save-dev @types/react-pointable@1.1.3
 ```
+
 
 ## License
 MIT

--- a/README.md
+++ b/README.md
@@ -76,11 +76,17 @@ All pointer events are supported:
 [Here's a CodePen using Pointable](http://codepen.io/MillerTime/pen/QKaLky/) that allows toggling between pointer and mouse events, using the same components.
 
 ## TypeScript Typings
-Typings for projects written in TypeScript are available on NPM:
+Typings for react-pointable are available on NPM.
 
+If you're using a version of React < 16.4, run
 ```
 npm install --save-dev @types/react-pointable@1.1.3
 ```
+If you happen to be using React 16.4+ and can't yet remove this package for some reason, you can instead run
+```
+npm install --save-dev @types/react-pointable
+```
+To learn more, see the discussion in the [DefinitelyTyped repo](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26363).
 
 
 ## License


### PR DESCRIPTION
See discussion at https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26363 -- typings for react-pointable had to be updated for compatibility with React 16.4 (since all of DefinitelyTyped is, unfortunately, versioned in lockstep). The upshot is that the latest version of `@types/react-pointable` will not expose pointer events when used with `@types/react` <16.4.